### PR TITLE
load fonts from any  [ ]byte, not only from local file

### DIFF
--- a/captcha.go
+++ b/captcha.go
@@ -65,6 +65,19 @@ func (c *Captcha) AddFont(path string) error {
 	return nil
 }
 
+//AddFontFromBytes allows to load font from slice of bytes, for example, load the font packed by https://github.com/jteeuwen/go-bindata
+func (c *Captcha) AddFontFromBytes(contents []byte) error {
+	font, err := freetype.ParseFont(contents)
+	if err != nil {
+		return err
+	}
+	if c.fonts == nil {
+		c.fonts = []*truetype.Font{}
+	}
+	c.fonts = append(c.fonts, font)
+	return nil
+}
+
 // SetFont 设置字体 可以设置多个
 func (c *Captcha) SetFont(paths ...string) error {
 	for _, v := range paths {

--- a/examples/main.go
+++ b/examples/main.go
@@ -18,6 +18,19 @@ func main() {
 		panic(err.Error())
 	}
 
+	/*
+	   //We can load font not only from localfile, but also from any []byte slice
+	   	fontContenrs, err := ioutil.ReadFile("comic.ttf")
+	   	if err != nil {
+	   		panic(err.Error())
+	   	}
+
+	   	err = cap.AddFontFromBytes(fontContenrs)
+	   	if err != nil {
+	   		panic(err.Error())
+	   	}
+	*/
+
 	cap.SetSize(128, 64)
 	cap.SetDisturbance(captcha.MEDIUM)
 	cap.SetFrontColor(color.RGBA{255, 255, 255, 255})


### PR DESCRIPTION
This feature will greatly help me to use fonts packed by 

https://github.com/jteeuwen/go-bindata 
