### PR TITLE
修正几个枚举值的类型

### DIFF
--- a/captcha.go
+++ b/captcha.go
@@ -24,18 +24,18 @@ type Captcha struct {
 type StrType int
 
 const (
-	NUM   StrType = 0 // 数字
-	LOWER         = 1 // 小写字母
-	UPPER         = 2 // 大写字母
-	ALL           = 3 // 全部
+	NUM   StrType = iota // 数字
+	LOWER                // 小写字母
+	UPPER                // 大写字母
+	ALL                  // 全部
 )
 
 type DisturLevel int
 
 const (
 	NORMAL DisturLevel = 4
-	MEDIUM             = 8
-	HIGH               = 16
+	MEDIUM DisturLevel = 8
+	HIGH   DisturLevel = 16
 )
 
 func New() *Captcha {


### PR DESCRIPTION
原先的定义方式，除了第一个值之外，其余的常量值的类型都是 int ，而不是期望的枚举类型
当以常量的方式传递给函数时并不会报错，但是如果用变量就会报错，例如：

    level := captcha.MEDIUM
    cap.SetDisturbance(level)

这里 level 的实际类型是 int，传递给`SetDisturbance`就会报错